### PR TITLE
install: Create dest dir if not present

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,9 @@ else
   DEST_DIR="$HOME/.local/share/icons"
 fi
 
-if [ -d "$DEST_DIR/WhiteSur-cursors" ]; then
+if [ ! -d "$DEST_DIR" ]; then
+  mkdir -p $DEST_DIR
+elif [ -d "$DEST_DIR/WhiteSur-cursors" ]; then
   rm -r "$DEST_DIR/WhiteSur-cursors"
 fi
 


### PR DESCRIPTION
Fixes:

```
➜  WhiteSur-cursors git:(master) ./install.sh
cp: unable to create directory '/home/simone/.local/share/icons/WhiteSur-cursors': File or directory not found
Finished...
```
