### PR TITLE
fix some issues in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ has_command() {
 if [ ! "$(which xcursorgen 2> /dev/null)" ]; then
 	echo xorg-xcursorgen needs to be installed to generate the cursors.
 	if has_command zypper; then
-		sudo zypper in xcursorgen
+		sudo zypper install -y xcursorgen
 	elif has_command apt-get; then
 		sudo apt-get install -y xorg-xcursorgen || sudo apt-get install -y x11-apps
 	elif has_command dnf; then
@@ -20,18 +20,18 @@ if [ ! "$(which xcursorgen 2> /dev/null)" ]; then
 	fi
 fi
 
-if [ ! "$(which inkscape 2> /dev/null)" ]; then
-	echo inkscape needs to be installed to generate the cursors.
+if [ ! "$(which rsvg-convert 2> /dev/null)" ]; then
+	echo rsvg-convert needs to be installed to generate the cursors.
 	if has_command zypper; then
-		sudo zypper in inkscape
+		sudo zypper install -y rsvg-convert
 	elif has_command apt-get; then
-		sudo apt-get install -y inkscape
+		sudo apt-get install -y librsvg2-bin
 	elif has_command dnf; then
-		sudo dnf install -y inkscape
+		sudo dnf install -y librsvg2 librsvg2-tools
 	elif has_command yum; then
-		sudo dnf install -y inkscape
+		sudo dnf install -y librsvg2 librsvg2-tools
 	elif has_command pacman; then
-		sudo pacman -S --noconfirm xorg-xcursorgen
+		sudo pacman -S --noconfirm librsvg
 	fi
 fi
 
@@ -39,10 +39,10 @@ function create {
 	cd "$SRC"
 	mkdir -p x1 x1_25 x1_5 x2
 	cd "$SRC"/$1
-	find . -name "*.svg" -type f -exec sh -c 'inkscape -o "../x1/${0%.svg}.png" -w 32 -h 32 $0' {} \;
-	find . -name "*.svg" -type f -exec sh -c 'inkscape -o "../x1_25/${0%.svg}.png" -w 40 -w 40 $0' {} \;
-	find . -name "*.svg" -type f -exec sh -c 'inkscape -o "../x1_5/${0%.svg}.png" -w 48 -w 48 $0' {} \;
-	find . -name "*.svg" -type f -exec sh -c 'inkscape -o "../x2/${0%.svg}.png" -w 64 -w 64 $0' {} \;
+	find . -name "*.svg" -exec sh -c 'rsvg-convert -w 32 -h 32 "$0" -o "../x1/$(basename "$0" .svg).png"' {} \;
+	find . -name "*.svg" -exec sh -c 'rsvg-convert -w 40 -h 40 "$0" -o "../x1_25/$(basename "$0" .svg).png"' {} \;
+	find . -name "*.svg" -exec sh -c 'rsvg-convert -w 48 -h 48 "$0" -o "../x1_5/$(basename "$0" .svg).png"' {} \;
+	find . -name "*.svg" -exec sh -c 'rsvg-convert -w 64 -h 64 "$0" -o "../x2/$(basename "$0" .svg).png"' {} \;
 
 	cd $SRC
 

--- a/build.sh
+++ b/build.sh
@@ -2,37 +2,37 @@
 
 # check command avalibility
 has_command() {
-  "$1" -v $1 > /dev/null 2>&1
+	command -v "$1" >/dev/null 2>&1
 }
 
 if [ ! "$(which xcursorgen 2> /dev/null)" ]; then
-  echo xorg-xcursorgen needs to be installed to generate the cursors.
-  if has_command zypper; then
-    sudo zypper in xorg-xcursorgen
-  elif has_command apt; then
-    sudo apt install xorg-xcursorgen
-  elif has_command dnf; then
-    sudo dnf install -y xorg-xcursorgen
-  elif has_command dnf; then
-    sudo dnf install xorg-xcursorgen
-  elif has_command pacman; then
-    sudo pacman -S --noconfirm xorg-xcursorgen
-  fi
+	echo xorg-xcursorgen needs to be installed to generate the cursors.
+	if has_command zypper; then
+		sudo zypper in xcursorgen
+	elif has_command apt-get; then
+		sudo apt-get install -y xorg-xcursorgen || sudo apt-get install -y x11-apps
+	elif has_command dnf; then
+		sudo dnf install -y xcursorgen
+	elif has_command yum; then
+		sudo dnf install -y xcursorgen
+	elif has_command pacman; then
+		sudo pacman -S --noconfirm xorg-xcursorgen
+	fi
 fi
 
 if [ ! "$(which inkscape 2> /dev/null)" ]; then
-  echo inkscape needs to be installed to generate the cursors.
-  if has_command zypper; then
-    sudo zypper in inkscape
-  elif has_command apt; then
-    sudo apt install inkscape
-  elif has_command dnf; then
-    sudo dnf install -y inkscape
-  elif has_command dnf; then
-    sudo dnf install inkscape
-  elif has_command pacman; then
-    sudo pacman -S --noconfirm inkscape
-  fi
+	echo inkscape needs to be installed to generate the cursors.
+	if has_command zypper; then
+		sudo zypper in inkscape
+	elif has_command apt-get; then
+		sudo apt-get install -y inkscape
+	elif has_command dnf; then
+		sudo dnf install -y inkscape
+	elif has_command yum; then
+		sudo dnf install -y inkscape
+	elif has_command pacman; then
+		sudo pacman -S --noconfirm xorg-xcursorgen
+	fi
 fi
 
 function create {


### PR DESCRIPTION
I noticed some issues with build.sh while trying to use it which I tried to fix.

Changes:
- spaces to tabs for consistency with the rest of the file
- the command check was broken, fixed
- xcursorgen is now part of the x11-apps pkg on ubuntu; added install for it; switched apt to apt-get (for stable cli)
- changed the xcursorgen pkg name to the valid one for other distros, replaced duplicate dnf with yum, other minor changes
- inkscape is an overkill for converting svgs to pngs so replaced it with rsvg-convert
- rsvg-convert has minimal dependencies, is faster, better suited for scripts
- fixed some typos in previous command (w, h were repeated)

Thanks