### PR TITLE
Add KDE svg cursors build support to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ has_command() {
 if [ ! "$(which xcursorgen 2> /dev/null)" ]; then
 	echo xorg-xcursorgen needs to be installed to generate the cursors.
 	if has_command zypper; then
-		sudo zypper in xcursorgen
+		sudo zypper install -y xcursorgen
 	elif has_command apt-get; then
 		sudo apt-get install -y xorg-xcursorgen || sudo apt-get install -y x11-apps
 	elif has_command dnf; then
@@ -20,18 +20,18 @@ if [ ! "$(which xcursorgen 2> /dev/null)" ]; then
 	fi
 fi
 
-if [ ! "$(which inkscape 2> /dev/null)" ]; then
-	echo inkscape needs to be installed to generate the cursors.
+if [ ! "$(which rsvg-convert 2> /dev/null)" ]; then
+	echo rsvg-convert needs to be installed to generate the cursors.
 	if has_command zypper; then
-		sudo zypper in inkscape
+		sudo zypper install -y rsvg-convert
 	elif has_command apt-get; then
-		sudo apt-get install -y inkscape
+		sudo apt-get install -y librsvg2-bin
 	elif has_command dnf; then
-		sudo dnf install -y inkscape
+		sudo dnf install -y librsvg2 librsvg2-tools
 	elif has_command yum; then
-		sudo dnf install -y inkscape
+		sudo dnf install -y librsvg2 librsvg2-tools
 	elif has_command pacman; then
-		sudo pacman -S --noconfirm xorg-xcursorgen
+		sudo pacman -S --noconfirm librsvg
 	fi
 fi
 
@@ -39,10 +39,10 @@ function create {
 	cd "$SRC"
 	mkdir -p x1 x1_25 x1_5 x2
 	cd "$SRC"/$1
-	find . -name "*.svg" -type f -exec sh -c 'inkscape -o "../x1/${0%.svg}.png" -w 32 -h 32 $0' {} \;
-	find . -name "*.svg" -type f -exec sh -c 'inkscape -o "../x1_25/${0%.svg}.png" -w 40 -w 40 $0' {} \;
-	find . -name "*.svg" -type f -exec sh -c 'inkscape -o "../x1_5/${0%.svg}.png" -w 48 -w 48 $0' {} \;
-	find . -name "*.svg" -type f -exec sh -c 'inkscape -o "../x2/${0%.svg}.png" -w 64 -w 64 $0' {} \;
+	find . -name "*.svg" -exec sh -c 'rsvg-convert -w 32 -h 32 "$0" -o "../x1/$(basename "$0" .svg).png"' {} \;
+	find . -name "*.svg" -exec sh -c 'rsvg-convert -w 40 -h 40 "$0" -o "../x1_25/$(basename "$0" .svg).png"' {} \;
+	find . -name "*.svg" -exec sh -c 'rsvg-convert -w 48 -h 48 "$0" -o "../x1_5/$(basename "$0" .svg).png"' {} \;
+	find . -name "*.svg" -exec sh -c 'rsvg-convert -w 64 -h 64 "$0" -o "../x2/$(basename "$0" .svg).png"' {} \;
 
 	cd $SRC
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #! /usr/bin/env bash
 
+# from where the command was run
+ROOT=$(pwd)
+
 # check command avalibility
 has_command() {
 	command -v "$1" >/dev/null 2>&1
@@ -32,6 +35,21 @@ if [ ! "$(which rsvg-convert 2> /dev/null)" ]; then
 		sudo dnf install -y librsvg2 librsvg2-tools
 	elif has_command pacman; then
 		sudo pacman -S --noconfirm librsvg
+	fi
+fi
+
+if [ ! "$(which python3 2> /dev/null)" ]; then
+	echo python3 needs to be installed to generate svg cursors.
+	if has_command zypper; then
+		sudo zypper install -y python3
+	elif has_command apt-get; then
+		sudo apt-get install -y python3
+	elif has_command dnf; then
+		sudo dnf install -y python3
+	elif has_command yum; then
+		sudo dnf install -y python3
+	elif has_command pacman; then
+		sudo pacman -S --noconfirm python
 	fi
 fi
 
@@ -95,8 +113,19 @@ function create {
 }
 
 # generate pixmaps from svg source
-SRC=$PWD/src
+SRC=$ROOT/src
 THEME="WhiteSur Cursors"
 
-create svg
+function svg-cursors {
+	cd $ROOT
+	rm -rf ./svg-cursor/
+	rm -rf ./dist/cursors_scalable/
+	git clone https://github.com/jinliu/svg-cursor.git
 
+	echo -e "Generating SVG cursors...\\r"
+	./svg-cursor/build-svg-theme/build-svg-theme.py --output-dir=$ROOT/dist/cursors_scalable --svg-dir=$SRC/svg --config-dir=$SRC/config --alias-file=$SRC/cursorList --nominal-size=24
+	echo -e "Generating SVG cursors... DONE"
+}
+
+create svg
+svg-cursors

--- a/build.sh
+++ b/build.sh
@@ -2,37 +2,37 @@
 
 # check command avalibility
 has_command() {
-  "$1" -v $1 > /dev/null 2>&1
+	command -v "$1" >/dev/null 2>&1
 }
 
 if [ ! "$(which xcursorgen 2> /dev/null)" ]; then
-  echo xorg-xcursorgen needs to be installed to generate the cursors.
-  if has_command zypper; then
-    sudo zypper in xorg-xcursorgen
-  elif has_command apt; then
-    sudo apt install xorg-xcursorgen
-  elif has_command dnf; then
-    sudo dnf install -y xorg-xcursorgen
-  elif has_command dnf; then
-    sudo dnf install xorg-xcursorgen
-  elif has_command pacman; then
-    sudo pacman -S --noconfirm xorg-xcursorgen
-  fi
+	echo xorg-xcursorgen needs to be installed to generate the cursors.
+	if has_command zypper; then
+		sudo zypper in xcursorgen
+	elif has_command apt-get; then
+		sudo apt-get install -y xorg-xcursorgen || sudo apt-get install -y x11-apps
+	elif has_command dnf; then
+		sudo dnf install -y xcursorgen
+	elif has_command yum; then
+		sudo dnf install -y xcursorgen
+	elif has_command pacman; then
+		sudo pacman -S --noconfirm xorg-xcursorgen
+	fi
 fi
 
 if [ ! "$(which inkscape 2> /dev/null)" ]; then
-  echo inkscape needs to be installed to generate the cursors.
-  if has_command zypper; then
-    sudo zypper in inkscape
-  elif has_command apt; then
-    sudo apt install inkscape
-  elif has_command dnf; then
-    sudo dnf install -y inkscape
-  elif has_command dnf; then
-    sudo dnf install inkscape
-  elif has_command pacman; then
-    sudo pacman -S --noconfirm inkscape
-  fi
+	echo inkscape needs to be installed to generate the cursors.
+	if has_command zypper; then
+		sudo zypper in inkscape
+	elif has_command apt-get; then
+		sudo apt-get install -y inkscape
+	elif has_command dnf; then
+		sudo dnf install -y inkscape
+	elif has_command yum; then
+		sudo dnf install -y inkscape
+	elif has_command pacman; then
+		sudo pacman -S --noconfirm xorg-xcursorgen
+	fi
 fi
 
 function create {

--- a/build.sh
+++ b/build.sh
@@ -123,7 +123,7 @@ function svg-cursors {
 	git clone https://github.com/jinliu/svg-cursor.git
 
 	echo -e "Generating SVG cursors...\\r"
-	./svg-cursor/build-svg-theme/build-svg-theme.py --output-dir=$ROOT/dist/cursors_scalable --svg-dir=$SRC/svg --config-dir=$SRC/config --alias-file=$SRC/cursorList --nominal-size=24
+	./svg-cursor/build-svg-theme/build-svg-theme.py --output-dir=$ROOT/dist/cursors_scalable --svg-dir=$SRC/svg --config-dir=$SRC/config --alias-file=$SRC/cursorList --nominal-size=24 >/dev/null 2>&1
 	echo -e "Generating SVG cursors... DONE"
 }
 


### PR DESCRIPTION
In a new function, `svg-cursors`, implemented basic logic for cloning https://github.com/jinliu/svg-cursor/ and using it to build svg cursors as per the instructions in https://github.com/jinliu/svg-cursor/tree/main/build-svg-theme.

Also reduced $PWD usage in the script.

includes https://github.com/vinceliuice/WhiteSur-cursors/pull/16. Only the last two commits are this pull.